### PR TITLE
Route Twitch events through message cache

### DIFF
--- a/services/MessageCacheManager.js
+++ b/services/MessageCacheManager.js
@@ -1,5 +1,6 @@
 const messageCache = new Map();
 const timers = new Map();
+const { randomUUID } = require('crypto');
 
 let messageHandler = null;
 const TTL = 60 * 1000;
@@ -10,23 +11,26 @@ export function registerMessageHandler(handler) {
 }
 
 export function addMessage(message) {
-    if (!message || !message.id) {
+    if (!message || typeof message !== 'object') {
         console.error('❌ Invalid message format:', message);
         return;
     }
-    if (timers.has(message.id)) {
-        clearTimeout(timers.get(message.id));
+
+    const id = message.id || randomUUID();
+
+    if (timers.has(id)) {
+        clearTimeout(timers.get(id));
     }
 
-    messageCache.set(message.id, { ...message, timestamp: Date.now() });
+    messageCache.set(id, { ...message, id, timestamp: Date.now() });
 
     const timer = setTimeout(() => {
-        messageCache.delete(message.id);
-        timers.delete(message.id);
+        messageCache.delete(id);
+        timers.delete(id);
         sendCached();
     }, TTL);
 
-    timers.set(message.id, timer);
+    timers.set(id, timer);
 
     cleanupMessages();
     sendCached();

--- a/src/components/ChatOverlay.jsx
+++ b/src/components/ChatOverlay.jsx
@@ -62,26 +62,13 @@ export default function ChatOverlay() {
             const { channel, payload } = JSON.parse(event.data);
             switch (channel) {
                 case 'chat:messages':
-                    // Берём последние 4 и помечаем их type: 'chat'
-                    const initial = payload.slice(-4).map(m => ({ ...m, type: 'chat' }));
+                    const initial = payload
+                        .slice(-4)
+                        .map(m => ({ ...m, type: m.type || 'chat' }));
                     setMessages(initial);
                     break;
                 case 'theme:update':
                     setTheme(payload);
-                    break;
-                case 'event:follow':
-                    setMessages(prev => {
-                        const next = [...prev, { ...payload, type: 'follow' }];
-                        if (next.length > 4) next.shift();
-                        return next;
-                    });
-                    break;
-                case 'event:redemption':
-                    setMessages(prev => {
-                        const next = [...prev, { ...payload, type: 'redemption' }];
-                        if (next.length > 4) next.shift();
-                        return next;
-                    });
                     break;
                 default:
                     console.log('unknown channel', channel, payload);


### PR DESCRIPTION
## Summary
- forward follow and redemption events to the `MessageCacheManager`
- auto-create message ids in the cache manager
- only listen to `chat:messages` in `ChatOverlay`

## Testing
- `npm run lint` *(fails: 'createGlobalStyle' is defined but never used, etc.)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684a1bc5b2f08320a5e43ec550064665