### PR TITLE
Add WebSocket reconnect logic

### DIFF
--- a/src/hooks/useReconnectingWebSocket.js
+++ b/src/hooks/useReconnectingWebSocket.js
@@ -1,0 +1,45 @@
+import { useEffect, useRef, useState } from 'react';
+
+export default function useReconnectingWebSocket(url, handlers = {}) {
+    const { onOpen, onMessage, onClose } = handlers;
+    const wsRef = useRef(null);
+    const reconnectRef = useRef(0);
+    const timerRef = useRef(null);
+    const [isConnected, setIsConnected] = useState(false);
+
+    const connect = () => {
+        clearTimeout(timerRef.current);
+        const ws = new WebSocket(url);
+        wsRef.current = ws;
+        ws.onopen = (e) => {
+            reconnectRef.current = 0;
+            setIsConnected(true);
+            if (onOpen) onOpen(e, ws);
+        };
+        if (onMessage) ws.onmessage = onMessage;
+        ws.onclose = (e) => {
+            setIsConnected(false);
+            if (onClose) onClose(e);
+            scheduleReconnect();
+        };
+        ws.onerror = () => {
+            ws.close();
+        };
+    };
+
+    const scheduleReconnect = () => {
+        const delay = Math.min(1000 * Math.pow(2, reconnectRef.current), 16000);
+        reconnectRef.current += 1;
+        timerRef.current = setTimeout(connect, delay);
+    };
+
+    useEffect(() => {
+        connect();
+        return () => {
+            clearTimeout(timerRef.current);
+            if (wsRef.current) wsRef.current.close();
+        };
+    }, [url]);
+
+    return { isConnected };
+}


### PR DESCRIPTION
## Summary
- create `useReconnectingWebSocket` hook
- reconnect chat overlay, preview, and audio player websocket connections
- show red connection warning on disconnect

## Testing
- `npm run lint` *(fails: unexpected lexical declaration etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68504f36fd308320860cd5e8b11fe696