### PR TITLE
Implement theme import/export and deletion

### DIFF
--- a/main.js
+++ b/main.js
@@ -193,6 +193,28 @@ app.whenReady().then(() => {
         }
     })
 
+    ipcMain.handle('theme:import', async (_event, { name, theme }) => {
+        const themes = store.get('themes');
+        themes[name] = theme;
+        store.set('themes', themes);
+        broadcast('themes:get', { themes, currentThemeName });
+    });
+
+    ipcMain.handle('theme:delete', async (_event, name) => {
+        const themes = store.get('themes');
+        if (themes[name]) {
+            delete themes[name];
+            store.set('themes', themes);
+            if (currentThemeName === name) {
+                currentThemeName = 'default';
+                currentTheme = themes[currentThemeName] || defaultTheme;
+                store.set('currentTheme', currentThemeName);
+                broadcast('theme:update', currentTheme);
+            }
+            broadcast('themes:get', { themes, currentThemeName });
+        }
+    });
+
     eventSubService.registerEventHandlers((destination, parsedEvent) => {
         if (destination === `${EVENT_CHANEL}:${EVENT_FOLLOW}`) {
             messageCache.addMessage({

--- a/main.js
+++ b/main.js
@@ -27,6 +27,10 @@ const WebSocket = require('ws');
 
 let currentThemeName = store.get('currentTheme') || "default";
 let currentTheme = store.get('themes')[currentThemeName] || require('./default-theme.json');
+messageCache.updateSettings({
+    lifetime: currentTheme.allMessages?.lifetime ?? 60,
+    maxCount: currentTheme.allMessages?.maxCount ?? 6,
+});
 
 const wss = new WebSocket.Server({ port: 42001 });
 
@@ -186,6 +190,10 @@ app.whenReady().then(() => {
             currentThemeName = themeName;
             currentTheme = themes[themeName];
             store.set('currentTheme', themeName);
+            messageCache.updateSettings({
+                lifetime: currentTheme.allMessages?.lifetime ?? 60,
+                maxCount: currentTheme.allMessages?.maxCount ?? 6,
+            });
             broadcast('theme:update', currentTheme);
             broadcast('themes:get', { themes, currentThemeName });
         } else {
@@ -209,6 +217,10 @@ app.whenReady().then(() => {
                 currentThemeName = 'default';
                 currentTheme = themes[currentThemeName] || defaultTheme;
                 store.set('currentTheme', currentThemeName);
+                messageCache.updateSettings({
+                    lifetime: currentTheme.allMessages?.lifetime ?? 60,
+                    maxCount: currentTheme.allMessages?.maxCount ?? 6,
+                });
                 broadcast('theme:update', currentTheme);
             }
             broadcast('themes:get', { themes, currentThemeName });
@@ -260,6 +272,10 @@ ipcMain.on('theme:update', (_e, theme, name) => {
     const themes = store.get('themes');
     themes[name] = theme;
     store.set('themes', themes);
+    messageCache.updateSettings({
+        lifetime: currentTheme.allMessages?.lifetime ?? 60,
+        maxCount: currentTheme.allMessages?.maxCount ?? 6,
+    });
     broadcast('theme:update', theme);
 });
 

--- a/src/components/ChatFollow.jsx
+++ b/src/components/ChatFollow.jsx
@@ -8,6 +8,9 @@ const Text = styled.span`
     //font-family: ${({theme}) => theme.followMessage.fontFamily};
     //font-weight: ${({theme}) => theme.followMessage.fontWeight};
     text-shadow: ${({theme}) => {
+        if (!theme.allMessages) {
+            return 'none';
+        }
         const {
             textShadowColor,
             textShadowOpacity,
@@ -18,7 +21,7 @@ const Text = styled.span`
         console.log(theme.allMessages);
         return `${textShadowXPosition}px ${textShadowYPosition}px ${textShadowRadius}px ${hexToRgba(textShadowColor, textShadowOpacity)}`;
     }};
-    color: ${({theme}) => theme.allMessages.textColor};
+    color: ${({theme}) => theme.allMessages?.textColor ?? '#fff'};
 `;
 
 
@@ -46,7 +49,7 @@ const MessageContainer = styled.div`
         return `0 0 ${shadowRadius}px ${hexToRgba(shadowColor, shadowOpacity)}`;
     }};
     backdrop-filter: ${({theme}) => {
-        if (theme.allMessages.blurRadius && theme.allMessages.blurRadius > 0) {
+        if (theme.allMessages?.blurRadius && theme.allMessages?.blurRadius > 0) {
             return `blur(${theme.allMessages.blurRadius}px)`;
         } else {
             return 'none';
@@ -57,9 +60,14 @@ const MessageContainer = styled.div`
 export default function ChatMessage({ message, template }) {
 
     function applyTemplate(template, data) {
-        return template.replace(/\{(\w+)}/g, (_, key) => {
-            return key in data ? data[key] : `{${key}}`;
-        });
+        try {
+            return template.replace(/\{(\w+)}/g, (_, key) => {
+                return key in data ? data[key] : `{${key}}`;
+            });
+        } catch (error) {
+            console.error("Error applying template:", error);
+            return 'format error';
+        }
     }
 
     const rendered = applyTemplate(template, { userName: message.userName });

--- a/src/components/ChatMessage.jsx
+++ b/src/components/ChatMessage.jsx
@@ -26,7 +26,7 @@ const MessageContainer = styled.div`
         return `0 0 ${shadowRadius}px ${hexToRgba(shadowColor, shadowOpacity)}`;
     }};
     backdrop-filter: ${({theme}) => {
-        if (theme.allMessages.blurRadius && theme.allMessages.blurRadius > 0) {
+        if (theme.allMessages?.blurRadius && theme.allMessages?.blurRadius > 0) {
             return `blur(${theme.allMessages.blurRadius}px)`;
         } else {
             return 'none';
@@ -45,6 +45,9 @@ const Username = styled.span`
     font-size: ${({theme}) => theme.chatMessage.titleFontSize}px;
     color: ${props => props.color || '#fff'};
     text-shadow: ${({theme}) => {
+        if (!theme.allMessages) {
+            return 'none';
+        }
         const {
             textShadowColor,
             textShadowOpacity,
@@ -60,6 +63,9 @@ const Username = styled.span`
 const MessageText = styled.span`
     display: inline-block;
     text-shadow: ${({theme}) => {
+        if (!theme.allMessages) {
+            return 'none';
+        }
         const {
             textShadowColor, 
             textShadowOpacity, 
@@ -70,7 +76,7 @@ const MessageText = styled.span`
         console.log(theme.allMessages);
         return `${textShadowXPosition}px ${textShadowYPosition}px ${textShadowRadius}px ${hexToRgba(textShadowColor, textShadowOpacity)}`;
     }};
-    color: ${({theme}) => theme.allMessages.textColor};
+    color: ${({theme}) => theme.allMessages?.textColor ?? '#fff'};
     font-size: ${({theme}) => theme.chatMessage.fontSize}px;
 `;
 

--- a/src/components/ChatRedemption.jsx
+++ b/src/components/ChatRedemption.jsx
@@ -29,6 +29,9 @@ const MessageContainer = styled.div`
     font-style: italic;
     color: ${props => props.color || '#fff'};
     text-shadow: ${({theme}) => {
+        if (!theme.allMessages) {
+            return 'none';
+        }
         const {
             textShadowColor,
             textShadowOpacity,
@@ -40,7 +43,7 @@ const MessageContainer = styled.div`
         return `${textShadowXPosition}px ${textShadowYPosition}px ${textShadowRadius}px ${hexToRgba(textShadowColor, textShadowOpacity)}`;
     }};
     backdrop-filter: ${({theme}) => {
-        if (theme.allMessages.blurRadius && theme.allMessages.blurRadius > 0) {
+        if (theme.allMessages?.blurRadius && theme.allMessages?.blurRadius > 0) {
             return `blur(${theme.allMessages.blurRadius}px)`;
         } else {
             return 'none';
@@ -51,9 +54,14 @@ const MessageContainer = styled.div`
 export default function ChatRedemption({ message, template }) {
 
     function applyTemplate(template, data) {
-        return template.replace(/\{(\w+)}/g, (_, key) => {
-            return key in data ? data[key] : `{${key}}`;
-        });
+        try {
+            return template.replace(/\{(\w+)}/g, (_, key) => {
+                return key in data ? data[key] : `{${key}}`;
+            });
+        } catch (error) {
+            console.error("Error applying template:", error);
+            return 'format error';
+        }
     }
 
     const rendered = applyTemplate(template, {

--- a/src/components/SettingsComponent.jsx
+++ b/src/components/SettingsComponent.jsx
@@ -44,6 +44,7 @@ const Content = styled.div`
 `;
 
 const ThemeName = styled.div`
+    flex-grow: 1;
     font-size: 1.2rem;
     font-weight: bold;
     border-radius: 4px;
@@ -51,6 +52,8 @@ const ThemeName = styled.div`
     color: #d6d6d6;
     padding: 8px;
     border: ${({ selected }) => (selected ? '1px solid #00ff00' : '1px solid transparent')};
+    width: ${({ selected }) => (selected ? 'calc(100% - 72px)' : '100%')};
+    transition: width 0.3s ease;
 `;
 
 const ThemeCreate = styled.div`
@@ -118,6 +121,8 @@ const ThemeItem = styled.div`
     display: flex;
     justify-content: space-between;
     align-items: center;
+    width: 100%;
+    gap: 4px;
 `;
 
 const ThemeActions = styled.div`

--- a/src/components/SettingsComponent.jsx
+++ b/src/components/SettingsComponent.jsx
@@ -2,7 +2,7 @@
 import React, {useEffect} from 'react';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
-import {openPreview, setRemoteTheme, createNewTheme, setTheme} from '../services/api';
+import {openPreview, setRemoteTheme, createNewTheme, setTheme, importTheme, deleteTheme} from '../services/api';
 import MessageSettingsBlock from "./app/MessageSettingsBlock";
 import FollowSettingsBlock from "./app/FollowSettingsBlock";
 import PlayerSettingsComponent from "./app/PlayerSettingsComponent";
@@ -114,6 +114,34 @@ const PopupContent = styled.div`
     gap: 8px;
 `;
 
+const ThemeItem = styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+`;
+
+const ThemeActions = styled.div`
+    display: flex;
+    gap: 4px;
+`;
+
+const ActionButton = styled.button`
+    border: 1px solid transparent;
+    padding: 4px 8px;
+    background: #3a3a3a;
+    color: #d6d6d6;
+    border-radius: 4px;
+    cursor: pointer;
+    &:hover {
+        background: #4a4a4a;
+        border-color: #646cff;
+    }
+`;
+
+const HiddenFileInput = styled.input`
+    display: none;
+`;
+
 export const Row = styled.div`
     display: flex;
     flex-direction: row;
@@ -126,6 +154,7 @@ export default function Settings() {
     const navigate = useNavigate();
 
     const themeNameRef = React.useRef(null);
+    const fileInputRef = React.useRef(null);
     const [isThemeSelectorOpen, setIsThemeSelectorOpen] = React.useState(false);
     const [selectedTheme, setSelectedTheme] = React.useState( defaultTheme);
     const [selectedThemeName, setSelectedThemeName] = React.useState("default");
@@ -184,6 +213,47 @@ export default function Settings() {
         }
     };
 
+    const handleExportTheme = (name) => {
+        const theme = themeList[name];
+        if (!theme) return;
+        const data = JSON.stringify({ [name]: theme }, null, 2);
+        const blob = new Blob([data], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `${name}.json`;
+        a.click();
+        URL.revokeObjectURL(url);
+    };
+
+    const handleDeleteTheme = (name) => {
+        if (window.confirm(`Delete theme "${name}"?`)) {
+            deleteTheme(name);
+        }
+    };
+
+    const triggerImport = () => {
+        fileInputRef.current?.click();
+    };
+
+    const handleFileChange = (e) => {
+        const file = e.target.files[0];
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = () => {
+            try {
+                const data = JSON.parse(reader.result);
+                const [name, theme] = Object.entries(data)[0] || [];
+                if (name && theme) {
+                    importTheme(name, theme);
+                }
+            } catch (err) {
+                console.error('Failed to import theme', err);
+            }
+        };
+        reader.readAsText(file);
+    };
+
     const handleThemeChange = (themeName) => {
         setTheme(themeName);
     }
@@ -194,14 +264,21 @@ export default function Settings() {
                 <Popup>
                     <PopupContent>
                         <ThemesTitle>Темы</ThemesTitle>
-                        { Object.keys(themeList).map((key, i) => (
-                            <ThemeName
-                                key={key}
-                                onClick={ () => { handleThemeChange(key) } }
-                                selected={key === selectedThemeName}
-                            >
-                                {key}
-                            </ThemeName>
+                        { Object.keys(themeList).map((key) => (
+                            <ThemeItem key={key}>
+                                <ThemeName
+                                    onClick={() => { handleThemeChange(key); }}
+                                    selected={key === selectedThemeName}
+                                >
+                                    {key}
+                                </ThemeName>
+                                {key === selectedThemeName && (
+                                    <ThemeActions>
+                                        <ActionButton onClick={() => handleExportTheme(key)}>📥</ActionButton>
+                                        <ActionButton onClick={() => handleDeleteTheme(key)}>🗑️</ActionButton>
+                                    </ThemeActions>
+                                )}
+                            </ThemeItem>
                         )) }
                         <ThemeCreate>
                             <label>
@@ -213,7 +290,13 @@ export default function Settings() {
                             </label>
                             <CreateThemeButton onClick={handleCreateThemeButton}>+</CreateThemeButton>
                         </ThemeCreate>
-                        <button onClick={() => setIsThemeSelectorOpen(false)}>Закрыть</button>
+                        <Row justify="space-between">
+                            <div>
+                                <ActionButton onClick={triggerImport}>Import</ActionButton>
+                                <HiddenFileInput ref={fileInputRef} type="file" accept=".json" onChange={handleFileChange} />
+                            </div>
+                            <ActionButton onClick={() => setIsThemeSelectorOpen(false)}>Закрыть</ActionButton>
+                        </Row>
                     </PopupContent>
                 </Popup>
             )}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,7 @@
-import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
+  <App />,
 )

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -50,3 +50,11 @@ export const openOverlay = () => {
 export const setRemoteTheme = (theme, name) => {
     ipcRenderer.send('theme:update', theme, name);
 }
+
+export const importTheme = (name, theme) => {
+    return ipcRenderer?.invoke('theme:import', { name, theme });
+};
+
+export const deleteTheme = (name) => {
+    return ipcRenderer?.invoke('theme:delete', name);
+};


### PR DESCRIPTION
## Summary
- add IPC calls for importing and deleting themes
- expose API helpers for new IPC events
- allow export, import and deletion of themes in Settings

## Testing
- `npm run build` *(fails: no script)*

------
https://chatgpt.com/codex/tasks/task_e_68505d5dfb648320b5b32d2bee8bf96b