### PR TITLE
Fix duplicate websocket connections

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,7 @@
-import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
+  <App />,
 )


### PR DESCRIPTION
## Summary
- remove `StrictMode` wrapper so web socket connections aren't initialized twice

## Testing
- `npm run lint` *(fails: 'no-undef' errors in existing codebase)*

------
https://chatgpt.com/codex/tasks/task_e_68506a3a5c788320bb10f682f01a1f45