### PR TITLE
Implement dynamic message cache settings

### DIFF
--- a/main.js
+++ b/main.js
@@ -27,6 +27,10 @@ const WebSocket = require('ws');
 
 let currentThemeName = store.get('currentTheme') || "default";
 let currentTheme = store.get('themes')[currentThemeName] || require('./default-theme.json');
+messageCache.updateSettings({
+    lifetime: currentTheme.allMessages?.lifetime ?? 60,
+    maxCount: currentTheme.allMessages?.maxCount ?? 6,
+});
 
 const wss = new WebSocket.Server({ port: 42001 });
 
@@ -186,6 +190,10 @@ app.whenReady().then(() => {
             currentThemeName = themeName;
             currentTheme = themes[themeName];
             store.set('currentTheme', themeName);
+            messageCache.updateSettings({
+                lifetime: currentTheme.allMessages?.lifetime ?? 60,
+                maxCount: currentTheme.allMessages?.maxCount ?? 6,
+            });
             broadcast('theme:update', currentTheme);
             broadcast('themes:get', { themes, currentThemeName });
         } else {
@@ -209,6 +217,10 @@ app.whenReady().then(() => {
                 currentThemeName = 'default';
                 currentTheme = themes[currentThemeName] || defaultTheme;
                 store.set('currentTheme', currentThemeName);
+                messageCache.updateSettings({
+                    lifetime: currentTheme.allMessages?.lifetime ?? 60,
+                    maxCount: currentTheme.allMessages?.maxCount ?? 6,
+                });
                 broadcast('theme:update', currentTheme);
             }
             broadcast('themes:get', { themes, currentThemeName });
@@ -260,6 +272,10 @@ ipcMain.on('theme:update', (_e, theme, name) => {
     const themes = store.get('themes');
     themes[name] = theme;
     store.set('themes', themes);
+    messageCache.updateSettings({
+        lifetime: currentTheme.allMessages?.lifetime ?? 60,
+        maxCount: currentTheme.allMessages?.maxCount ?? 6,
+    });
     broadcast('theme:update', theme);
 });
 


### PR DESCRIPTION
## Summary
- allow MessageCacheManager TTL and cache size to be updated from theme settings
- update cache behaviour when lifetime is 0 (disable) or negative (infinite)
- refresh cache settings on theme changes

## Testing
- `npm run lint` *(fails: 'require' is not defined errors)*

------
https://chatgpt.com/codex/tasks/task_e_68509110e9788320842d7d1d150fe9af