### PR TITLE
Add connection status block

### DIFF
--- a/main.js
+++ b/main.js
@@ -24,6 +24,7 @@ const store = new Store({
 });
 
 const WebSocket = require('ws');
+const appStartTime = Date.now();
 
 let currentThemeName = store.get('currentTheme') || "default";
 let currentTheme = store.get('themes')[currentThemeName] || require('./default-theme.json');
@@ -175,6 +176,22 @@ app.whenReady().then(() => {
 
     ipcMain.handle('setting:open-preview', () => {
        createPreviewWindow();
+    });
+
+    ipcMain.handle('system:get-stats', () => {
+        return {
+            startTime: appStartTime,
+            lastEventSub: eventSubService.getLastEventTimestamp(),
+            lastIRC: chatService.getLastEventTimestamp(),
+        };
+    });
+
+    ipcMain.handle('system:reconnect', async () => {
+        eventSubService.stop();
+        chatService.stopChat();
+        eventSubService.start();
+        chatService.startChat();
+        return true;
     });
 
     ipcMain.handle('theme:create', async (event, newThemeName) => {

--- a/services/chatService.js
+++ b/services/chatService.js
@@ -11,6 +11,7 @@ let client = null;
 let messageHandler = null;
 let isStopping = false;
 let isConnecting = false;
+let lastEventTimestamp = Date.now();
 
 // reconnect when auth tokens are refreshed
 authService.onTokenRefreshed(() => {
@@ -80,6 +81,7 @@ async function connect() {
 
     client.connect(PORT, HOST, () => {
         isConnecting = false;
+        lastEventTimestamp = Date.now();
         console.log('🟢 Connected to Twitch IRC');
         client.write(`CAP REQ :twitch.tv/tags twitch.tv/commands twitch.tv/membership\r\n`);
         client.write(`PASS oauth:${accessToken}\r\n`);
@@ -88,6 +90,7 @@ async function connect() {
     });
 
     client.on('data', (data) => {
+        lastEventTimestamp = Date.now();
         const messages = data.toString().split('\r\n');
 
         messages.forEach(message => {
@@ -145,4 +148,5 @@ module.exports = {
     startChat,
     stopChat,
     registerMessageHandler,
+    getLastEventTimestamp: () => lastEventTimestamp,
 };

--- a/services/eventSubService.js
+++ b/services/eventSubService.js
@@ -20,6 +20,7 @@ let isConnecting = false;
 let connectUrl = DEFAULT_URL;
 let skipSubscribe = false;
 let ignoreClose = false;
+let lastEventTimestamp = Date.now();
 
 // restart EventSub websocket when tokens are refreshed
 authService.onTokenRefreshed(() => {
@@ -58,12 +59,14 @@ async function start(url = DEFAULT_URL, skipSub = false) {
 
     ws.on('open', () => {
         isConnecting = false;
+        lastEventTimestamp = Date.now();
         console.log('🟢 Connected to Twitch EventSub WebSocket');
     });
 
     ws.on('ping', () => ws.pong());
 
     ws.on('message', async (data) => {
+        lastEventTimestamp = Date.now();
         const msg = JSON.parse(data);
         const { metadata, payload } = msg;
 
@@ -253,4 +256,9 @@ function stop(setStopping = true, ignore = false) {
     isConnecting = false;
 }
 
-module.exports = { start, stop, registerEventHandlers };
+module.exports = {
+    start,
+    stop,
+    registerEventHandlers,
+    getLastEventTimestamp: () => lastEventTimestamp,
+};

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -104,7 +104,16 @@ const StatusBlock = styled.div`
     display: flex;
     flex-direction: column;
     gap: 4px;
+    border: 1px solid #444;
+    box-shadow: -2px -2px 3px rgba(144, 144, 144, 0.2);
     align-items: flex-end;
+
+    opacity: 0.3;
+    transition: opacity 0.2s ease;
+
+    &:hover {
+        opacity: 1;
+    }
 `;
 
 const StatLine = styled.span``;
@@ -169,7 +178,7 @@ export default function Dashboard() {
     };
 
     const eventSubColor = sinceEventSub > 120000 ? 'red' : sinceEventSub > 30000 ? 'yellow' : '#b0b0b0';
-    const ircColor = sinceIRC > 120000 ? 'red' : sinceIRC > 60000 ? 'yellow' : '#b0b0b0';
+    const ircColor = sinceIRC > 360000 ? 'red' : sinceIRC > 300000 ? 'yellow' : '#b0b0b0';
 
     const handleReconnect = () => {
         reconnect();

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -58,3 +58,11 @@ export const importTheme = (name, theme) => {
 export const deleteTheme = (name) => {
     return ipcRenderer?.invoke('theme:delete', name);
 };
+
+export const getStats = () => {
+    return ipcRenderer?.invoke('system:get-stats');
+};
+
+export const reconnect = () => {
+    return ipcRenderer?.invoke('system:reconnect');
+};


### PR DESCRIPTION
## Summary
- show a new status block on dashboard with uptime, last EventSub event, last IRC event, and reconnect button
- track last event times in IRC and EventSub services
- expose stats and reconnection IPC handlers
- add API helpers for stats and reconnect

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' and shows lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685099c87e708320b5384367c49e7b70