### PR TITLE
Fix small emotes on large fonts

### DIFF
--- a/services/messageParser.js
+++ b/services/messageParser.js
@@ -83,7 +83,7 @@ function parseEmotes(message, emotesTag) {
     for (let i = 0; i < chars.length; i++) {
         if (emoteMap[i]) {
             const { end, emoteId } = emoteMap[i];
-            result += `<img src="https://static-cdn.jtvnw.net/emoticons/v2/${emoteId}/default/dark/1.0" alt="emote" style="vertical-align: middle;" />`;
+            result += `<img src="https://static-cdn.jtvnw.net/emoticons/v2/${emoteId}/default/dark/1.0" alt="emote" style="vertical-align: middle; height: 1em;" />`;
             i = end;
         } else {
             result += escapeHtml(chars[i]);

--- a/src/components/ChatMessage.jsx
+++ b/src/components/ChatMessage.jsx
@@ -78,6 +78,9 @@ const MessageText = styled.span`
     }};
     color: ${({theme}) => theme.allMessages?.textColor ?? '#fff'};
     font-size: ${({theme}) => theme.chatMessage.fontSize}px;
+    img {
+        height: 1em;
+    }
 `;
 
 export default function ChatMessage({ message }) {


### PR DESCRIPTION
## Summary
- ensure emote `<img>` tags scale with the font size in chat messages
- apply the same `height: 1em` rule for images inside `ChatMessage`

## Testing
- `npm run lint` *(fails: 'module' is not defined errors)*

------
https://chatgpt.com/codex/tasks/task_e_6851e70140648320921eedc6e43efec8