### PR TITLE
Fix reconnection logic for EventSub

### DIFF
--- a/main.js
+++ b/main.js
@@ -187,7 +187,9 @@ app.whenReady().then(() => {
     });
 
     ipcMain.handle('system:reconnect', async () => {
-        eventSubService.stop();
+        // Ignore the automatic reconnect triggered on close so we don't create
+        // duplicate EventSub connections when manually restarting
+        eventSubService.stop({ setStopping: false, ignoreClose: true });
         chatService.stopChat();
         eventSubService.start();
         chatService.startChat();


### PR DESCRIPTION
## Summary
- prevent duplicate EventSub connections when tokens refresh
- prevent duplicate EventSub connections when manually reconnecting
- monitor EventSub for inactivity and restart if it goes silent
- switch `stop()` to accept an options object for clarity

## Testing
- `npm ci`
- `npm run lint` *(fails: module not defined, no-undef, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6852923f0d78832096831cdf89b73dd3