### PR TITLE
Add role restoration for roulette mutes

### DIFF
--- a/services/authService.ts
+++ b/services/authService.ts
@@ -37,6 +37,8 @@ const SCOPES = [
   'moderator:read:followers',
   'moderator:manage:chat_messages',
   'moderator:manage:banned_users',
+  'channel:manage:moderators',
+  'channel:manage:vips',
   'chat:read',
   'chat:edit',
   'bits:read',

--- a/services/authorizedHelixApi.ts
+++ b/services/authorizedHelixApi.ts
@@ -33,7 +33,7 @@ interface RoleCacheEntry {
   expiresAt: number;
 }
 
-const ROLE_CACHE_DURATION = 10 * 60 * 1000; // 10 minutes
+const ROLE_CACHE_DURATION = 60 * 1000; // 1 minutes
 const roleCache: Map<string, RoleCacheEntry> = new Map();
 
 export async function getUserRoles(user_id: string): Promise<UserRoles> {

--- a/services/authorizedHelixApi.ts
+++ b/services/authorizedHelixApi.ts
@@ -28,7 +28,20 @@ export interface UserRoles {
   isModerator: boolean;
 }
 
+interface RoleCacheEntry {
+  roles: UserRoles;
+  expiresAt: number;
+}
+
+const ROLE_CACHE_DURATION = 10 * 60 * 1000; // 10 minutes
+const roleCache: Map<string, RoleCacheEntry> = new Map();
+
 export async function getUserRoles(user_id: string): Promise<UserRoles> {
+  const cached = roleCache.get(user_id);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.roles;
+  }
+
   const tokens = await authService.getTokens();
   if (!tokens?.access_token) throw new Error('No access token');
   const broadcaster_id = await authService.getUserId();
@@ -50,7 +63,9 @@ export async function getUserRoles(user_id: string): Promise<UserRoles> {
   const isVip = Array.isArray(vipResp.data.data) && vipResp.data.data.length > 0;
   const isModerator = Array.isArray(modResp.data.data) && modResp.data.data.length > 0;
 
-  return { isVip, isModerator };
+  const roles = { isVip, isModerator };
+  roleCache.set(user_id, { roles, expiresAt: Date.now() + ROLE_CACHE_DURATION });
+  return roles;
 }
 
 export async function addVip(user_id: string): Promise<void> {

--- a/services/authorizedHelixApi.ts
+++ b/services/authorizedHelixApi.ts
@@ -22,3 +22,86 @@ export async function timeoutUser(
     },
   });
 }
+
+export interface UserRoles {
+  isVip: boolean;
+  isModerator: boolean;
+}
+
+export async function getUserRoles(user_id: string): Promise<UserRoles> {
+  const tokens = await authService.getTokens();
+  if (!tokens?.access_token) throw new Error('No access token');
+  const broadcaster_id = await authService.getUserId();
+  if (!broadcaster_id) throw new Error('No broadcaster id');
+
+  const headers = {
+    Authorization: `Bearer ${tokens.access_token}`,
+    'Client-Id': authService.CLIENT_ID,
+  };
+
+  const vipParams = new URLSearchParams({ broadcaster_id: String(broadcaster_id), user_id });
+  const modParams = new URLSearchParams({ broadcaster_id: String(broadcaster_id), user_id });
+
+  const [vipResp, modResp] = await Promise.all([
+    axios.get(`https://api.twitch.tv/helix/channels/vips?${vipParams}` , { headers }),
+    axios.get(`https://api.twitch.tv/helix/moderation/moderators?${modParams}`, { headers }),
+  ]);
+
+  const isVip = Array.isArray(vipResp.data.data) && vipResp.data.data.length > 0;
+  const isModerator = Array.isArray(modResp.data.data) && modResp.data.data.length > 0;
+
+  return { isVip, isModerator };
+}
+
+export async function addVip(user_id: string): Promise<void> {
+  const tokens = await authService.getTokens();
+  if (!tokens?.access_token) throw new Error('No access token');
+  const broadcaster_id = await authService.getUserId();
+  const params = new URLSearchParams({ broadcaster_id: String(broadcaster_id), user_id });
+  await axios.post(`https://api.twitch.tv/helix/channels/vips?${params}`, null, {
+    headers: {
+      Authorization: `Bearer ${tokens.access_token}`,
+      'Client-Id': authService.CLIENT_ID,
+    },
+  });
+}
+
+export async function removeVip(user_id: string): Promise<void> {
+  const tokens = await authService.getTokens();
+  if (!tokens?.access_token) throw new Error('No access token');
+  const broadcaster_id = await authService.getUserId();
+  const params = new URLSearchParams({ broadcaster_id: String(broadcaster_id), user_id });
+  await axios.delete(`https://api.twitch.tv/helix/channels/vips?${params}`, {
+    headers: {
+      Authorization: `Bearer ${tokens.access_token}`,
+      'Client-Id': authService.CLIENT_ID,
+    },
+  });
+}
+
+export async function addModerator(user_id: string): Promise<void> {
+  const tokens = await authService.getTokens();
+  if (!tokens?.access_token) throw new Error('No access token');
+  const broadcaster_id = await authService.getUserId();
+  const params = new URLSearchParams({ broadcaster_id: String(broadcaster_id), user_id });
+  await axios.post(`https://api.twitch.tv/helix/moderation/moderators?${params}`, null, {
+    headers: {
+      Authorization: `Bearer ${tokens.access_token}`,
+      'Client-Id': authService.CLIENT_ID,
+    },
+  });
+}
+
+export async function removeModerator(user_id: string): Promise<void> {
+  const tokens = await authService.getTokens();
+  if (!tokens?.access_token) throw new Error('No access token');
+  const broadcaster_id = await authService.getUserId();
+  const params = new URLSearchParams({ broadcaster_id: String(broadcaster_id), user_id });
+  await axios.delete(`https://api.twitch.tv/helix/moderation/moderators?${params}`, {
+    headers: {
+      Authorization: `Bearer ${tokens.access_token}`,
+      'Client-Id': authService.CLIENT_ID,
+    },
+  });
+}
+

--- a/services/middleware/GreetingMiddleware.ts
+++ b/services/middleware/GreetingMiddleware.ts
@@ -14,7 +14,7 @@ export default class GreetingMiddleware extends Middleware {
   private commands: CompiledCommand[] = [];
   private enabled = true;
 
-  processMessage(message: any) {
+  async processMessage(message: any) {
     if (!this.enabled) {
       console.log('⏩ GreetingMiddleware is disabled, skipping message processing');
       return { message, actions: [], accepted: false };

--- a/services/middleware/Middleware.ts
+++ b/services/middleware/Middleware.ts
@@ -2,9 +2,10 @@ import {BotConfig} from "./MiddlewareProcessor";
 
 export default class Middleware {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  processMessage(message: any): { message: any; actions: any[]; accepted: boolean } {
+  async processMessage(message: any): Promise<{ message: any; actions: any[]; accepted: boolean }> {
     throw new Error('processMessage not implemented');
   }
+
   updateConfig(config: BotConfig): void {
     throw new Error('updateConfig not implemented');
   }

--- a/services/middleware/MiddlewareProcessor.ts
+++ b/services/middleware/MiddlewareProcessor.ts
@@ -46,7 +46,7 @@ export class MiddlewareProcessor {
     const actions: { type: ActionType; payload: any }[] = [];
     let currentMessage = message;
     for (const middleware of this.middlewares) {
-      const result = middleware.processMessage(currentMessage);
+      const result = await middleware.processMessage(currentMessage);
       if (result.message !== undefined) currentMessage = result.message;
       if (result.actions?.length) actions.push(...result.actions);
       if (result.accepted) break;

--- a/services/middleware/RoleRestoreManager.ts
+++ b/services/middleware/RoleRestoreManager.ts
@@ -1,0 +1,40 @@
+import { addVip, removeVip, addModerator, removeModerator, getUserRoles, UserRoles } from '../authorizedHelixApi';
+
+interface StoredUser {
+  username: string;
+  roles: UserRoles;
+  timer: NodeJS.Timeout;
+}
+
+export default class RoleRestoreManager {
+  private muted: Map<string, StoredUser> = new Map();
+
+  async prepareMute(userId: string, username: string, duration: number): Promise<boolean> {
+    try {
+      const roles = await getUserRoles(userId);
+      const timer = setTimeout(() => {
+        this.restoreRoles(userId).catch(err => console.error('Failed to restore roles', err));
+      }, duration);
+      this.muted.set(userId, { username, roles, timer });
+      if (roles.isModerator) await removeModerator(userId);
+      if (roles.isVip) await removeVip(userId);
+      return true;
+    } catch (e) {
+      console.error('Failed to prepare mute:', (e as any).message);
+      return false;
+    }
+  }
+
+  async restoreRoles(userId: string): Promise<void> {
+    const data = this.muted.get(userId);
+    if (!data) return;
+    this.muted.delete(userId);
+    const { roles } = data;
+    try {
+      if (roles.isModerator) await addModerator(userId);
+      if (roles.isVip) await addVip(userId);
+    } catch (e) {
+      console.error('Failed to restore roles for', userId, (e as any).message);
+    }
+  }
+}

--- a/services/middleware/RoleRestoreManager.ts
+++ b/services/middleware/RoleRestoreManager.ts
@@ -16,8 +16,6 @@ export default class RoleRestoreManager {
         this.restoreRoles(userId).catch(err => console.error('Failed to restore roles', err));
       }, duration);
       this.muted.set(userId, { username, roles, timer });
-      if (roles.isModerator) await removeModerator(userId);
-      if (roles.isVip) await removeVip(userId);
       return true;
     } catch (e) {
       console.error('Failed to prepare mute:', (e as any).message);

--- a/services/middleware/RouletteService.ts
+++ b/services/middleware/RouletteService.ts
@@ -14,6 +14,7 @@ export default class RouletteService extends Middleware {
   private enabled: boolean;
   private cooldowns: Map<string, number> = new Map();
   private roleManager = new RoleRestoreManager();
+  private chance: number;
 
   constructor(
     muteDuration = 2 * 60 * 1000,
@@ -61,6 +62,7 @@ export default class RouletteService extends Middleware {
     this.cooldownMessages = cooldownMessages;
     this.muteDuration = muteDuration;
     this.enabled = enabled;
+    this.chance = 18;
   }
 
     updateConfig(config: BotConfig) {
@@ -71,6 +73,7 @@ export default class RouletteService extends Middleware {
       this.cooldownMessages = config.roulette.cooldownMessage;
       this.muteDuration = config.roulette.muteDuration;
       this.enabled = config.roulette.enabled;
+      this.chance = config.roulette.chance || 18;
       console.log('✅ RouletteService config updated:', config.roulette);
     }
 
@@ -104,7 +107,13 @@ export default class RouletteService extends Middleware {
           accepted: true,
           message: { ...message },
           actions: [
-            { type: ActionTypes.SEND_MESSAGE, payload: { message: 'чтото внутри пошло не так', forwardToUi: true } },
+            {
+              type: ActionTypes.SEND_MESSAGE,
+              payload: {
+                message: `@${message.username}, ты же не думаешь, что ты, что сидит за экраном, и ты здесь, в Сети - это одно и то же?`,
+                forwardToUi: true
+              }
+            },
           ],
         };
       }
@@ -122,8 +131,11 @@ export default class RouletteService extends Middleware {
   }
 
   private checkRouletteWin(): boolean {
-    const ROULETTE_CHANCE = 6;
-    return Math.floor(Math.random() * ROULETTE_CHANCE) + 1 === 1;
+    if (this.chance <= 0) return false;
+    if (this.chance >= 1) return true;
+    const roll = Math.random();
+    console.log(`🎲 Roulette roll: ${roll} (chance: ${this.chance})`);
+    return roll < this.chance;
   }
 
   private getRandomMessage(array: string[], username: string): string {


### PR DESCRIPTION
## Summary
- support async middleware processing
- keep track of user roles when roulette mutes a user
- restore saved roles after mute ends
- add helper API methods for VIP/moderator management

## Testing
- `npm run build:ts`
- `npm run lint` *(fails: 199 problems)*

------
https://chatgpt.com/codex/tasks/task_e_687ae19d70c883208acc7afff3bcbbd3